### PR TITLE
Add the git package as dependency for pygit2

### DIFF
--- a/scripts/installer/install_detector.sh
+++ b/scripts/installer/install_detector.sh
@@ -18,7 +18,7 @@ SSH_KEY_PATH="/root/.ssh"
 SSH_KEY="$SSH_KEY_PATH/id_rsa"
 SSH_KEY_PUB="$SSH_KEY_PATH/id_rsa.pub"
 
-REQUIRED_PKGS="curl pwgen apache2-utils jq git python-pygit2 libssh2-1"
+REQUIRED_PKGS="curl pwgen apache2-utils jq git xz-utils python-pygit2 libssh2-1"
 SALT_STATES="detector/detector,detector/nginx"
 
 S4A_USER="s4a"

--- a/scripts/installer/install_detector.sh
+++ b/scripts/installer/install_detector.sh
@@ -18,7 +18,7 @@ SSH_KEY_PATH="/root/.ssh"
 SSH_KEY="$SSH_KEY_PATH/id_rsa"
 SSH_KEY_PUB="$SSH_KEY_PATH/id_rsa.pub"
 
-REQUIRED_PKGS="curl pwgen apache2-utils jq python-pygit2 libssh2-1"
+REQUIRED_PKGS="curl pwgen apache2-utils jq git python-pygit2 libssh2-1"
 SALT_STATES="detector/detector,detector/nginx"
 
 S4A_USER="s4a"


### PR DESCRIPTION
This fixes an issue, when the git package is not available on the host.
The python-pygit2 library needs the git package as well to operate.
The python-pygit2 module provides git filesystem backend capabilites to salt