### PR TITLE
Resolve stale pid file issue with suricata ver 4.x.x

### DIFF
--- a/saltstack/salt/detector/files/suricata/suricata.service
+++ b/saltstack/salt/detector/files/suricata/suricata.service
@@ -8,7 +8,8 @@ Type=forking
 Restart=always
 TimeoutStartSec=8
 RestartSec=8
-ExecStart=/usr/bin/suricata {% for val in int %}{{ space() }}--pfring-int={{ val }}{% endfor %} --pfring-cluster-id=99 --pfring-cluster-type=cluster_flow -c /etc/suricata/suricata.yaml -D
+ExecStartPre=/bin/rm -f @e_rundir@suricata.pid
+ExecStart=/usr/bin/suricata {% for val in int %}{{ space() }}--pfring-int={{ val }}{% endfor %} --pfring-cluster-id=99 --pfring-cluster-type=cluster_flow -c /etc/suricata/suricata.yaml --pidfile @e_rundir@suricata.pid -D
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStop=/bin/kill $MAINPID
 


### PR DESCRIPTION
Suricata version 4 and up by design is not able to remove pid file, if privileges are dropped. This breaks the next startup.
Fix is to add a pre start command to unit file that removes the pid file.
Also defining the pid file location in the start command.
Source: https://github.com/OISF/suricata/blob/master/etc/suricata.service.in