### PR TITLE
! ciphers was not used, instead I found 'cipher'

### DIFF
--- a/saltstack/pillar/vpn/init.sls
+++ b/saltstack/pillar/vpn/init.sls
@@ -22,5 +22,5 @@ openvpn:
     proto: tcp
     status: /var/log/openvpn-status.log
     verb: 1
-    ciphers: AES-128-CBC
+    cipher: AES-128-CBC
     routes:


### PR DESCRIPTION
Minor fix suggestion
https://github.com/cert-ee/s4a/blob/master/saltstack/salt/vpn/files/client.ovpn.jinja#L33