### PR TITLE
network interfaces to separate file in /etc/network/interfaces.d/

### DIFF
--- a/saltstack/salt/detector/deps.sls
+++ b/saltstack/salt/detector/deps.sls
@@ -101,6 +101,7 @@ vm.max_map_count:
 capture_interface_{{ val }}:
   network.managed:
     - name: {{ val }}
+    - filename: {{ val }}
     - enabled: True
     - type: eth
     - proto: manual


### PR DESCRIPTION
Updating network configuration dependency as requested.

**Before merging, note this**
Current network.managed state has overwritten Ubuntu's default network 
configuration, which, to point this out, means that it lacks critical line for 
new configuration:
```
source /etc/network/interfaces.d/*
```
It would be nice and clean to remove old configuration from /etc/network/interfaces
as well, but this doesn't exactly break anything, configuration from interfaces.d/
will be applied after this.