### PR TITLE
Improve rounding in the moloch daily.sh script

### DIFF
--- a/saltstack/salt/detector/files/moloch/moloch.cron.daily.jinja
+++ b/saltstack/salt/detector/files/moloch/moloch.cron.daily.jinja
@@ -26,8 +26,9 @@ done
 # Get average of all returned index sizes
 average=`echo $sizes | jq -s 'add/length'`
 
-# Convert average to GB
-gb=$((`printf "%.0f\n" $average`/1024/1024/1024))
+# Convert average to GB and round up
+ngb=$(echo $average | awk '{ byte =$1 /1024/1024/1024; print byte}')
+gb=$(printf "%.0f" $ngb)
 
 # Make sure that $gb is not zero
 if [ $gb -eq 0 ] ; then


### PR DESCRIPTION
Change how rounding is done. Fixes an example edge case where 2,9 GB was rounded to 2 instead of 3 causing the elasticsearch data partition to fill up.